### PR TITLE
Korean

### DIFF
--- a/akevolve.html
+++ b/akevolve.html
@@ -361,6 +361,7 @@
                     case "en":$('#display-lang').text("English");break;
                     case "cn":$('#display-lang').text("Chinese");break;
                     case "jp":$('#display-lang').text("Japanese");break;
+                    case "kr":$('#display-lang').text("Korean");break;
                 }
                 loadMaterials();
             }

--- a/json/akmaterial.json
+++ b/json/akmaterial.json
@@ -3,6 +3,7 @@
     "id": 0,
     "name_cn": "D32钢",
     "name_en": "D32 Steel",
+    "name_kr": "D32강",
     "level": 5,
     "source": {},
     "madeof": {
@@ -14,7 +15,8 @@
   {
     "id": 1,
     "name_cn": "双极纳米片",
-    "name_en":"Bipolar Nanoplate",
+    "name_en": "Bipolar Nanoplate",
+    "name_kr": "바이폴라 나노플레이크 칩",
     "level": 5,
     "source": {},
     "madeof": {
@@ -25,7 +27,8 @@
   {
     "id": 2,
     "name_cn": "聚合剂",
-    "name_en":"Aggregate Agent",
+    "name_en": "Aggregate Agent",
+    "name_kr": "중합제",
     "level": 5,
     "source": {},
     "madeof": {
@@ -37,7 +40,8 @@
   {
     "id": 3,
     "name_cn": "RMA70-24",
-    "name_en":"RMA70-24",
+    "name_en": "RMA70-24",
+    "name_kr": "RMA70-24",
     "level": 4,
     "source": {
       "4-9": "Very Rare"
@@ -51,7 +55,8 @@
   {
     "id": 4,
     "name_cn": "五水研磨石",
-    "name_en":"Pentahydrate Polish Stone",
+    "name_en": "Pentahydrate Polish Stone",
+    "name_kr": "고급연마석",
     "level": 4,
     "source": {
       "4-8": "Very Rare"
@@ -65,7 +70,8 @@
   {
     "id": 5,
     "name_cn": "三水锰矿",
-    "name_en":"Manganese Block",
+    "name_en": "Manganese Block",
+    "name_kr": "망간 중합체",
     "level": 4,
     "source": {
       "4-7": "Very Rare"
@@ -79,7 +85,8 @@
   {
     "id": 6,
     "name_cn": "白马醇",
-    "name_en":"White Horse Alcohol",
+    "name_en": "White Horse Alcohol",
+    "name_kr": "화이트 호스 콜",
     "level": 4,
     "source": {
       "4-4": "Very Rare"
@@ -93,7 +100,8 @@
   {
     "id": 7,
     "name_cn": "改量装置",
-    "name_en":"Quantum Gadget",
+    "name_en": "Quantum Gadget",
+    "name_kr": "개량 장치",
     "level": 4,
     "source": {
       "4-10": "Very Rare"
@@ -107,7 +115,8 @@
   {
     "id": 8,
     "name_cn": "酮阵列",
-    "name_en":"Ketone Arrangement",
+    "name_en": "Ketone Arrangement",
+    "name_kr": "아케톤 팩",
     "level": 4,
     "source": {
       "4-5": "Very Rare",
@@ -122,7 +131,8 @@
   {
     "id": 9,
     "name_cn": "异铁块",
-    "name_en":"Mass Xeno Iron",
+    "name_en": "Mass Xeno Iron",
+    "name_kr": "이철 팩",
     "level": 4,
     "source": {
       "S4-1": "Very Rare",
@@ -137,7 +147,8 @@
   {
     "id": 10,
     "name_cn": "聚酸酯块",
-    "name_en":"Polyester Box",
+    "name_en": "Polyester Box",
+    "name_kr": "폴리에스테르 팩",
     "level": 4,
     "source": {
       "3-8": "Very Rare"
@@ -151,7 +162,8 @@
   {
     "id": 11,
     "name_cn": "糖聚块",
-    "name_en":"Sugar Box",
+    "name_en": "Sugar Box",
+    "name_kr": "포도당 팩",
     "level": 4,
     "source": {
       "4-2": "Very Rare",
@@ -166,7 +178,8 @@
   {
     "id": 12,
     "name_cn": "提纯源岩",
-    "name_en":"Refined Rock",
+    "name_en": "Refined Rock",
+    "name_kr": "정제 원암",
     "level": 4,
     "source": {
       "4-6": "Very Rare"
@@ -178,7 +191,8 @@
   {
     "id": 13,
     "name_cn": "全新装置",
-    "name_en":"Current Gadget",
+    "name_en": "Current Gadget",
+    "name_kr": "리뉴얼 장치",
     "level": 3,
     "source": {
       "3-4": "Rare",
@@ -192,7 +206,8 @@
   {
     "id": 14,
     "name_cn": "酮凝集组",
-    "name_en":" Flocculated Ketone Case",
+    "name_en": "Flocculated Ketone Case",
+    "name_kr": "아케톤 응집체 번들",
     "level": 3,
     "source": {
       "3-1": "Rare",
@@ -206,7 +221,8 @@
   {
     "id": 15,
     "name_cn": "异铁组",
-    "name_en":"Xeno Iron Chunk",
+    "name_en": "Xeno Iron Chunk",
+    "name_kr": "이철 번들",
     "level": 3,
     "source": {
       "2-8": "Rare",
@@ -220,7 +236,8 @@
   {
     "id": 16,
     "name_cn": "聚酸酯组",
-    "name_en":"Polyester Pack",
+    "name_en": "Polyester Pack",
+    "name_kr": "폴리에스테르 번들",
     "level": 3,
     "source": {
       "2-6": "Rare",
@@ -234,7 +251,8 @@
   {
     "id": 17,
     "name_cn": "糖组",
-    "name_en":"Sugar Pack",
+    "name_en": "Sugar Pack",
+    "name_kr": "포도당 번들",
     "level": 3,
     "source": {
       "2-5": "Rare",
@@ -248,7 +266,8 @@
   {
     "id": 18,
     "name_cn": "固源岩组",
-    "name_en":"Rock Set",
+    "name_en": "Rock Set",
+    "name_kr": "원암 큐브 번들",
     "level": 3,
     "source": {
       "2-4": "Rare",
@@ -262,7 +281,8 @@
   {
     "id": 19,
     "name_cn": "装置",
-    "name_en":"Gadget",
+    "name_en": "Gadget",
+    "name_kr": "장치",
     "level": 2,
     "source": {
       "1-12": "Medium",
@@ -276,7 +296,8 @@
   {
     "id": 20,
     "name_cn": "酮凝集",
-    "name_en":"Flocculated Ketone",
+    "name_en": "Flocculated Ketone",
+    "name_kr": "아케톤 응집체",
     "level": 2,
     "source": {
       "S2-1": "Medium",
@@ -289,7 +310,8 @@
   {
     "id": 21,
     "name_cn": "异铁",
-    "name_en":"Xeno Iron",
+    "name_en": "Xeno Iron",
+    "name_kr": "이철",
     "level": 2,
     "source": {
       "2-1": "Medium",
@@ -303,7 +325,8 @@
   {
     "id": 22,
     "name_cn": "聚酸酯",
-    "name_en":"Polyester",
+    "name_en": "Polyester",
+    "name_kr": "폴리에스테르",
     "level": 2,
     "source": {
       "1-8": "Common",
@@ -317,7 +340,8 @@
   {
     "id": 23,
     "name_cn": "糖",
-    "name_en":"Sugar",
+    "name_en": "Sugar",
+    "name_kr": "포도당",
     "level": 2,
     "source": {
       "2-2": "Common",
@@ -332,7 +356,8 @@
   {
     "id": 24,
     "name_cn": "固源岩",
-    "name_en":"Rock Block",
+    "name_en": "Rock Block",
+    "name_kr": "원암 큐브",
     "level": 2,
     "source": {
       "1-7": "Always",
@@ -347,7 +372,8 @@
   {
     "id": 25,
     "name_cn": "破损装置",
-    "name_en":"Broken Gadget",
+    "name_en": "Broken Gadget",
+    "name_kr": "파손된 장치",
     "level": 1,
     "source": {
       "1-5": "Medium",
@@ -358,7 +384,8 @@
   {
     "id": 26,
     "name_cn": "双酮",
-    "name_en":"Ketone",
+    "name_en": "Ketone",
+    "name_kr": "디케톤",
     "level": 1,
     "source": {
       "1-6": "Common",
@@ -369,7 +396,8 @@
   {
     "id": 27,
     "name_cn": "异铁碎片",
-    "name_en":"Xeno Iron Shard",
+    "name_en": "Xeno Iron Shard",
+    "name_kr": "이철 조각",
     "level": 1,
     "source": {
       "1-3": "Common",
@@ -380,7 +408,8 @@
   {
     "id": 28,
     "name_cn": "酯原料",
-    "name_en":"Raw Ester",
+    "name_en": "Raw Ester",
+    "name_kr": "에스테르 원료",
     "level": 1,
     "source": {
       "0-11": "Always",
@@ -391,7 +420,8 @@
   {
     "id": 29,
     "name_cn": "代糖",
-    "name_en":"Sugar Substitute",
+    "name_en": "Sugar Substitute",
+    "name_kr": "대체당",
     "level": 1,
     "source": {
       "0-7": "Always",
@@ -402,7 +432,8 @@
   {
     "id": 30,
     "name_cn": "源岩",
-    "name_en":"Rock",
+    "name_en": "Rock",
+    "name_kr": "원암",
     "level": 1,
     "source": {
       "0-9": "Always",
@@ -413,7 +444,8 @@
   {
     "id": 31,
     "name_cn": "扭转醇",
-    "name_en":"Twist Alcohol",
+    "name_en": "Twist Alcohol",
+    "name_kr": "로식 콜",
     "level": 3,
     "source": {
       "2-9": "Rare",
@@ -425,7 +457,8 @@
   {
     "id": 32,
     "name_cn": "研磨石",
-    "name_en":"Polish Stone",
+    "name_en": "Polish Stone",
+    "name_kr": "연마석",
     "level": 3,
     "source": {
       "3-3": "Rare",
@@ -437,7 +470,8 @@
   {
     "id": 33,
     "name_cn": "轻锰矿",
-    "name_en":"Manganese Ore",
+    "name_en": "Manganese Ore",
+    "name_kr": "망간 광석",
     "level": 3,
     "source": {
       "3-2": "Rare",
@@ -449,7 +483,8 @@
   {
     "id": 34,
     "name_cn": "RMA70-12",
-    "name_en":"RMA70-12",
+    "name_en": "RMA70-12",
+    "name_kr": "RMA70-12",
     "level": 3,
     "source": {
       "2-10": "Rare",
@@ -461,7 +496,8 @@
   {
     "id": 35,
     "name_cn": "先锋芯片",
-    "name_en":"Vanguard Chip",
+    "name_en": "Vanguard Chip",
+    "name_kr": "뱅가드 칩",
     "level": 2,
     "source": {
       "PR-C-1": "Always"
@@ -472,7 +508,8 @@
   {
     "id": 36,
     "name_cn": "先锋芯片组",
-    "name_en":"Vanguard Chip Set",
+    "name_en": "Vanguard Chip Set",
+    "name_kr": "뱅가드 칩셋",
     "level": 3,
     "source": {
       "PR-C-2": "Always"
@@ -483,7 +520,8 @@
   {
     "id": 37,
     "name_cn": "先锋双芯片",
-    "name_en":"Vanguard Twin Chip",
+    "name_en": "Vanguard Twin Chip",
+    "name_kr": "뱅가드 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -492,7 +530,8 @@
   {
     "id": 38,
     "name_cn": "近卫芯片",
-    "name_en":"Guard Chip",
+    "name_en": "Guard Chip",
+    "name_kr": "가드 칩",
     "level": 2,
     "source": {
       "PR-D-1": "Always"
@@ -503,7 +542,8 @@
   {
     "id": 39,
     "name_cn": "近卫芯片组",
-    "name_en":"Guard Chip Set",
+    "name_en": "Guard Chip Set",
+    "name_kr": "가드 칩셋",
     "level": 3,
     "source": {
       "PR-D-2": "Always"
@@ -514,7 +554,8 @@
   {
     "id": 40,
     "name_cn": "近卫双芯片",
-    "name_en":"Guard Twin Chip",
+    "name_en": "Guard Twin Chip",
+    "name_kr": "가드 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -523,7 +564,8 @@
   {
     "id": 41,
     "name_cn": "重装芯片",
-    "name_en":"Tank Chip",
+    "name_en": "Tank Chip",
+    "name_kr": "디펜더 칩",
     "level": 2,
     "source": {
       "PR-A-1": "Always"
@@ -534,7 +576,8 @@
   {
     "id": 42,
     "name_cn": "重装芯片组",
-    "name_en":"Tank Chip Set",
+    "name_en": "Tank Chip Set",
+    "name_kr": "디펜더 칩셋",
     "level": 3,
     "source": {
       "PR-A-2": "Always"
@@ -545,7 +588,8 @@
   {
     "id": 43,
     "name_cn": "重装双芯片",
-    "name_en":"Tank Twin Chip",
+    "name_en": "Tank Twin Chip",
+    "name_kr": "디펜더 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -554,7 +598,8 @@
   {
     "id": 44,
     "name_cn": "狙击芯片",
-    "name_en":"Sniper Chip",
+    "name_en": "Sniper Chip",
+    "name_kr": "스나이퍼 칩",
     "level": 2,
     "source": {
       "PR-B-1": "Always"
@@ -565,7 +610,8 @@
   {
     "id": 45,
     "name_cn": "狙击芯片组",
-    "name_en":"Sniper Chip Set",
+    "name_en": "Sniper Chip Set",
+    "name_kr": "스나이퍼 칩셋",
     "level": 3,
     "source": {
       "PR-B-2": "Always"
@@ -576,7 +622,8 @@
   {
     "id": 46,
     "name_cn": "狙击双芯片",
-    "name_en":"Sniper Twin Chip",
+    "name_en": "Sniper Twin Chip",
+    "name_kr": "스나이퍼 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -585,7 +632,8 @@
   {
     "id": 47,
     "name_cn": "术师芯片",
-    "name_en":"Caster Chip",
+    "name_en": "Caster Chip",
+    "name_kr": "캐스터 칩",
     "level": 2,
     "source": {
       "PR-B-1": "Always"
@@ -596,7 +644,8 @@
   {
     "id": 48,
     "name_cn": "术师芯片组",
-    "name_en":"Caster Chip Set",
+    "name_en": "Caster Chip Set",
+    "name_kr": "캐스터 칩셋",
     "level": 3,
     "source": {
       "PR-B-2": "Always"
@@ -607,7 +656,8 @@
   {
     "id": 49,
     "name_cn": "术师双芯片",
-    "name_en":"Caster Twin Chip",
+    "name_en": "Caster Twin Chip",
+    "name_kr": "캐스터 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -616,7 +666,8 @@
   {
     "id": 50,
     "name_cn": "医疗芯片",
-    "name_en":"Medic Chip",
+    "name_en": "Medic Chip",
+    "name_kr": "메딕 칩",
     "level": 2,
     "source": {
       "PR-A-1": "Always"
@@ -627,7 +678,8 @@
   {
     "id": 51,
     "name_cn": "医疗芯片组",
-    "name_en":"Medic Chip Set",
+    "name_en": "Medic Chip Set",
+    "name_kr": "메딕 칩셋",
     "level": 3,
     "source": {
       "PR-A-2": "Always"
@@ -638,7 +690,8 @@
   {
     "id": 52,
     "name_cn": "医疗双芯片",
-    "name_en":"Medic Twin Chip",
+    "name_en": "Medic Twin Chip",
+    "name_kr": "메딕 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -647,7 +700,8 @@
   {
     "id": 53,
     "name_cn": "辅助芯片",
-    "name_en":"Support Chip",
+    "name_en": "Support Chip",
+    "name_kr": "서포터 칩",
     "level": 2,
     "source": {
       "PR-C-1": "Always"
@@ -658,7 +712,8 @@
   {
     "id": 54,
     "name_cn": "辅助芯片组",
-    "name_en":"Support Chip Set",
+    "name_en": "Support Chip Set",
+    "name_kr": "서포터 칩셋",
     "level": 3,
     "source": {
       "PR-C-2": "Always"
@@ -669,7 +724,8 @@
   {
     "id": 55,
     "name_cn": "辅助双芯片",
-    "name_en":"Support Twin Chip",
+    "name_en": "Support Twin Chip",
+    "name_kr": "서포터 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -678,7 +734,8 @@
   {
     "id": 56,
     "name_cn": "特种芯片",
-    "name_en":"Specialist Chip",
+    "name_en": "Specialist Chip",
+    "name_kr": "스페셜리스트 칩",
     "level": 2,
     "source": {
       "PR-D-1": "Always"
@@ -689,7 +746,8 @@
   {
     "id": 57,
     "name_cn": "特种芯片组",
-    "name_en":"Specialist Chip Set",
+    "name_en": "Specialist Chip Set",
+    "name_kr": "스페셜리스트 칩셋",
     "level": 3,
     "source": {
       "PR-D-2": "Always"
@@ -700,7 +758,8 @@
   {
     "id": 58,
     "name_cn": "特种双芯片",
-    "name_en":"Specialist Twin Chip",
+    "name_en": "Specialist Twin Chip",
+    "name_kr": "스페셜리스트 듀얼 칩",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -709,7 +768,8 @@
   {
     "id": 59,
     "name_cn": "龙门币",
-    "name_en":"Lungmen Coin",
+    "name_en": "Lungmen Coin",
+    "name_kr": "용문폐",
     "level": 1,
     "source": {},
     "madeof": {},
@@ -718,7 +778,8 @@
   {
     "id": 60,
     "name_cn": "芯片助剂",
-    "name_en":"Chip Additive",
+    "name_en": "Chip Additive",
+    "name_kr": "칩 촉매제",
     "level": 1,
     "source": {},
     "madeof": {},

--- a/json/tl-gender.json
+++ b/json/tl-gender.json
@@ -3,12 +3,12 @@
         "sex_cn":"女",
         "sex_en":"Female",
         "sex_jp":"女",
-        "sex_kr":""
+        "sex_kr":"여자"
     },
     {
         "sex_cn":"男",
         "sex_en":"Male",
         "sex_jp":"男",
-        "sex_kr":""
+        "sex_kr":"남자"
     }
 ]

--- a/json/tl-item.json
+++ b/json/tl-item.json
@@ -1,274 +1,342 @@
 [
   {    
     "name_cn": "D32钢",
-    "name_en": "D32 Steel"
+    "name_en": "D32 Steel",
+    "name_kr": "D32강"
   },
   {    
     "name_cn": "双极纳米片",
-    "name_en":"Bipolar Nanoplate"
+    "name_en": "Bipolar Nanoplate",
+    "name_kr": "바이폴라 나노플레이크 칩"
   },
   {    
     "name_cn": "聚合剂",
-    "name_en":"Aggregate Agent"
+    "name_en": "Aggregate Agent",
+    "name_kr": "중합제"
   },
   {    
     "name_cn": "RMA70-24",
-    "name_en":"RMA70-24"
+    "name_en": "RMA70-24",
+    "name_kr": "RMA70-24"
   },
   {    
     "name_cn": "五水研磨石",
-    "name_en":"Pentahydrate Polish Stone"
+    "name_en": "Pentahydrate Polish Stone",
+    "name_kr": "고급연마석"
   },
   {    
     "name_cn": "三水锰矿",
-    "name_en":"Manganese Block"
+    "name_en": "Manganese Block",
+    "name_kr": "망간 중합체"
   },
   {    
     "name_cn": "白马醇",
-    "name_en":"White Horse Alcohol"
+    "name_en": "White Horse Alcohol",
+    "name_kr": "화이트 호스 콜"
   },
   {    
     "name_cn": "改量装置",
-    "name_en":"Quantum Gadget"
+    "name_en": "Quantum Gadget",
+    "name_kr": "개량 장치"
   },
   {    
     "name_cn": "酮阵列",
-    "name_en":"Ketone Arrangement"
+    "name_en": "Ketone Arrangement",
+    "name_kr": "아케톤 팩"
   },
   {    
     "name_cn": "异铁块",
-    "name_en":"Mass Xeno Iron"
+    "name_en": "Mass Xeno Iron",
+    "name_kr": "이철 팩"
   },
   {
     "name_cn": "聚酸酯块",
-    "name_en":"Polyester Box"
+    "name_en": "Polyester Box",
+    "name_kr": "폴리에스테르 팩"
   },
   {
     "name_cn": "糖聚块",
-    "name_en":"Sugar Box"
+    "name_en": "Sugar Box",
+    "name_kr": "포도당 팩"
   },
   {
     "name_cn": "提纯源岩",
-    "name_en":"Refined Rock"
+    "name_en": "Refined Rock",
+    "name_kr": "정제 원암"
   },
   {
     "name_cn": "全新装置",
-    "name_en":"Current Gadget"
+    "name_en": "Current Gadget",
+    "name_kr": "리뉴얼 장치"
   },
   {
     "name_cn": "酮凝集组",
-    "name_en":" Flocculated Ketone Case"
+    "name_en": "Flocculated Ketone Case",
+    "name_kr": "아케톤 응집체 번들"
   },
   {
     "name_cn": "异铁组",
-    "name_en":"Xeno Iron Chunk"
+    "name_en": "Xeno Iron Chunk",
+    "name_kr": "이철 번들"
   },
   {
     "name_cn": "聚酸酯组",
-    "name_en":"Polyester Pack"
+    "name_en": "Polyester Pack",
+    "name_kr": "폴리에스테르 번들"
   },
   {
     "name_cn": "糖组",
-    "name_en":"Sugar Pack"
+    "name_en": "Sugar Pack",
+    "name_kr": "포도당 번들"
   },
   {
     "name_cn": "固源岩组",
-    "name_en":"Rock Set"
+    "name_en": "Rock Set",
+    "name_kr": "원암 큐브 번들"
   },
   {
     "name_cn": "装置",
-    "name_en":"Gadget"
+    "name_en": "Gadget",
+    "name_kr": "장치"
   },
   {
     "name_cn": "酮凝集",
-    "name_en":"Flocculated Ketone"
+    "name_en": "Flocculated Ketone",
+    "name_kr": "아케톤 응집체"
   },
   {
     "name_cn": "异铁",
-    "name_en":"Xeno Iron"
+    "name_en": "Xeno Iron",
+    "name_kr": "이철"
   },
   {
     "name_cn": "聚酸酯",
-    "name_en":"Polyester"
+    "name_en": "Polyester",
+    "name_kr": "폴리에스테르"
   },
   {
     "name_cn": "糖",
-    "name_en":"Sugar"
+    "name_en": "Sugar",
+    "name_kr": "포도당"
   },
   {
     "name_cn": "固源岩",
-    "name_en":"Rock Block"
+    "name_en": "Rock Block",
+    "name_kr": "원암 큐브"
   },
   {
     "name_cn": "破损装置",
-    "name_en":"Broken Gadget"
+    "name_en": "Broken Gadget",
+    "name_kr": "파손된 장치"
   },
   {
     "name_cn": "双酮",
-    "name_en":"Ketone"
+    "name_en": "Ketone",
+    "name_kr": "디케톤"
   },
   {
     "name_cn": "异铁碎片",
-    "name_en":"Xeno Iron Shard"
+    "name_en": "Xeno Iron Shard",
+    "name_kr": "이철 조각"
   },
   {
     "name_cn": "酯原料",
-    "name_en":"Raw Ester"
+    "name_en": "Raw Ester",
+    "name_kr": "에스테르 원료"
   },
   {
     "name_cn": "代糖",
-    "name_en":"Sugar Substitute"
+    "name_en": "Sugar Substitute",
+    "name_kr": "대체당"
   },
   {
     "name_cn": "源岩",
-    "name_en":"Rock"
+    "name_en": "Rock",
+    "name_kr": "원암"
   },
   {
     "name_cn": "扭转醇",
-    "name_en":"Twist Alcohol"
+    "name_en": "Twist Alcohol",
+    "name_kr": "로식 콜"
   },
   {
     "name_cn": "研磨石",
-    "name_en":"Polish Stone"
+    "name_en": "Polish Stone",
+    "name_kr": "연마석"
   },
   {
     "name_cn": "轻锰矿",
-    "name_en":"Manganese Ore"
+    "name_en": "Manganese Ore",
+    "name_kr": "망간 광석"
   },
   {
     "name_cn": "RMA70-12",
-    "name_en":"RMA70-12"
+    "name_en": "RMA70-12",
+    "name_kr": "RMA70-12"
   },
   {
     "name_cn": "先锋芯片",
-    "name_en":"Vanguard Chip"
+    "name_en": "Vanguard Chip",
+    "name_kr": "뱅가드 칩"
   },
   {
     "name_cn": "先锋芯片组",
-    "name_en":"Vanguard Chip Set"
+    "name_en": "Vanguard Chip Set",
+    "name_kr": "뱅가드 칩셋"
   },
   {
     "name_cn": "先锋双芯片",
-    "name_en":"Vanguard Twin Chip"
+    "name_en": "Vanguard Twin Chip",
+    "name_kr": "뱅가드 듀얼 칩"
   },
   {
     "name_cn": "近卫芯片",
-    "name_en":"Guard Chip"
+    "name_en": "Guard Chip",
+    "name_kr": "가드 칩"
   },
   {
     "name_cn": "近卫芯片组",
-    "name_en":"Guard Chip Set"
+    "name_en": "Guard Chip Set",
+    "name_kr": "가드 칩셋"
   },
   {
     "name_cn": "近卫双芯片",
-    "name_en":"Guard Twin Chip"
+    "name_en": "Guard Twin Chip",
+    "name_kr": "가드 듀얼 칩"
   },
   {
     "name_cn": "重装芯片",
-    "name_en":"Tank Chip"
+    "name_en": "Tank Chip",
+    "name_kr": "디펜더 칩"
   },
   {
     "name_cn": "重装芯片组",
-    "name_en":"Tank Chip Set"
+    "name_en": "Tank Chip Set",
+    "name_kr": "디펜더 칩셋"
   },
   {
     "name_cn": "重装双芯片",
-    "name_en":"Tank Twin Chip"
+    "name_en": "Tank Twin Chip",
+    "name_kr": "디펜더 듀얼 칩"
   },
   {
     "name_cn": "狙击芯片",
-    "name_en":"Sniper Chip"
+    "name_en": "Sniper Chip",
+    "name_kr": "스나이퍼 칩"
   },
   {
     "name_cn": "狙击芯片组",
-    "name_en":"Sniper Chip Set"
+    "name_en": "Sniper Chip Set",
+    "name_kr": "스나이퍼 칩셋"
   },
   {
     "name_cn": "狙击双芯片",
-    "name_en":"Sniper Twin Chip"
+    "name_en": "Sniper Twin Chip",
+    "name_kr": "스나이퍼 듀얼 칩"
   },
   {
     "name_cn": "术师芯片",
-    "name_en":"Caster Chip"
+    "name_en": "Caster Chip",
+    "name_kr": "캐스터 칩"
   },
   {
     "name_cn": "术师芯片组",
-    "name_en":"Caster Chip Set"
+    "name_en": "Caster Chip Set",
+    "name_kr": "캐스터 칩셋"
   },
   {
     "name_cn": "术师双芯片",
-    "name_en":"Caster Twin Chip"
+    "name_en": "Caster Twin Chip",
+    "name_kr": "캐스터 듀얼 칩"
   },
   {
     "name_cn": "医疗芯片",
-    "name_en":"Medic Chip"
+    "name_en": "Medic Chip",
+    "name_kr": "메딕 칩"
   },
   {
     "name_cn": "医疗芯片组",
-    "name_en":"Medic Chip Set"
+    "name_en": "Medic Chip Set",
+    "name_kr": "메딕 칩셋"
   },
   {
     "name_cn": "医疗双芯片",
-    "name_en":"Medic Twin Chip"
+    "name_en": "Medic Twin Chip",
+    "name_kr": "메딕 듀얼 칩"
   },
   {
     "name_cn": "辅助芯片",
-    "name_en":"Support Chip"
+    "name_en": "Support Chip",
+    "name_kr": "서포터 칩"
   },
   {
     "name_cn": "辅助芯片组",
-    "name_en":"Support Chip Set"
+    "name_en": "Support Chip Set",
+    "name_kr": "서포터 칩셋"
   },
   {
     "name_cn": "辅助双芯片",
-    "name_en":"Support Twin Chip"
+    "name_en": "Support Twin Chip",
+    "name_kr": "서포터 듀얼 칩"
   },
   {
     "name_cn": "特种芯片",
-    "name_en":"Specialist Chip"
+    "name_en": "Specialist Chip",
+    "name_kr": "스페셜리스트 칩"
   },
   {
     "name_cn": "特种芯片组",
-    "name_en":"Specialist Chip Set"
+    "name_en": "Specialist Chip Set",
+    "name_kr": "스페셜리스트 칩셋"
   },
   {
     "name_cn": "特种双芯片",
-    "name_en":"Specialist Twin Chip"
+    "name_en": "Specialist Twin Chip",
+    "name_kr": "스페셜리스트 듀얼 칩"
   },
   {
     "name_cn": "龙门币",
-    "name_en":"Lungmen Coin"
+    "name_en": "Lungmen Coin",
+    "name_kr": "용문폐"
   },
   {
     "name_cn": "芯片助剂",
-    "name_en":"Chip Additive"
+    "name_en": "Chip Additive",
+    "name_kr": "칩 촉매제"
   },
   {
     "name_cn": "技巧概要·卷1",
-    "name_en":"Skill Book  Vol.1"
+    "name_en": "Skill Book  Vol.1",
+    "name_kr": "스킬개론 제1권"
   },
   {
     "name_cn": "技巧概要·卷2",
-    "name_en":"Skill Book Vol.2"
+    "name_en": "Skill Book Vol.2",
+    "name_kr": "스킬개론 제2권"
   },
   {
     "name_cn": "技巧概要·卷3",
-    "name_en":"Skill Book Vol.3"
+    "name_en": "Skill Book Vol.3",
+    "name_kr": "스킬개론 제3권"
   },
   {
     "name_cn": "凝胶",
-    "name_en":"Synthetic Resin"
+    "name_en": "Synthetic Resin",
+    "name_kr": ""
   },
   {
     "name_cn": "聚合凝胶",
-    "name_en":"Fined Synthetic Resin"
+    "name_en": "Fined Synthetic Resin",
+    "name_kr": ""
   },
   {
     "name_cn": "炽合金",
-    "name_en":"Silicic Alloy"
+    "name_en": "Silicic Alloy",
+    "name_kr": ""
   },
   {
     "name_cn": "炽合金块",
-    "name_en":"Silicic Alloy Block"
+    "name_en": "Silicic Alloy Block",
+    "name_kr": ""
   }
 ]

--- a/json/tl-ui.json
+++ b/json/tl-ui.json
@@ -53,14 +53,14 @@
         "ui_cn":"服务器",
         "ui_en":"Server",
         "ui_jp":"Server",
-        "ui_kr":"Server"
+        "ui_kr":"서버"
     },
     {
         "id":"language-2",
         "ui_cn":"语言",
         "ui_en":"Language",
         "ui_jp":"Language",
-        "ui_kr":"Language"
+        "ui_kr":"언어"
     },
     {
         "id":"selector-title",
@@ -102,7 +102,7 @@
         "ui_cn":"词缀",
         "ui_en":"Affix",
         "ui_jp":"特徴",
-        "ui_kr":"태그"
+        "ui_kr":"특징"
     },
     {
         "id":"selector-categories-6",
@@ -144,83 +144,83 @@
         "ui_cn":"选择: ",
         "ui_en":"Selected: ",
         "ui_jp":"",
-        "ui_kr":""
+        "ui_kr":"선택됨: "
     },
     {
         "id":"selector-clear",
         "ui_cn":"清空",
         "ui_en":"Clear",
         "ui_jp":"クリア",
-        "ui_kr":"초기화"
+        "ui_kr":"태그"
     },
     {
         "id":"result-tags",
         "ui_cn":"Tags",
         "ui_en":"Tags",
         "ui_jp":"Tags",
-        "ui_kr":"Tags"
+        "ui_kr":"태그"
     },
     {
         "id":"clear-tags",
         "ui_cn":"Tags",
         "ui_en":"Tags",
         "ui_jp":"Tags",
-        "ui_kr":"Tags"
+        "ui_kr":"개 초기화하기"
     },
     {
         "id":"result-characters",
         "ui_cn":"可能出现",
         "ui_en":"Character Possibility",
         "ui_jp":"キャラクター確率",
-        "ui_kr":"캐릭터 확률"
+        "ui_kr":"캐릭터 결과"
     },
     {
         "id":"footer-instructions-1",
         "ui_cn":"使用说明：",
         "ui_en":"How To Use ：",
         "ui_jp":"How To Use ：",
-        "ui_kr":"How To Use ："
+        "ui_kr":"사용법 ："
     },
     {
         "id":"footer-instructions-2",
         "ui_cn":"1. Change the 'Game Server' drop down on the top right according to your AK client region.",
         "ui_en":"1. Change the 'Game Server' drop down on the top right according to your AK client region.",
         "ui_jp":"1. Change the 'Game Server' drop down on the top right according to your AK client region.",
-        "ui_kr":"1. Change the 'Game Server' drop down on the top right according to your AK client region."
+        "ui_kr":"1. 오른쪽 위의 '서버'에서 사용 중인 명일방주 클라이언트의 서버를 선택하세요."
     },
     {
         "id":"footer-instructions-3",
         "ui_cn":"2. Change the language of the user interface to your preference.",
         "ui_en":"2. Change the language of the user interface to your preference.",
         "ui_jp":"2. Change the language of the user interface to your preference.",
-        "ui_kr":"2. Change the language of the user interface to your preference."
+        "ui_kr":"2. 오른쪽 위의 '언어'에서 UI 언어를 바꾸세요."
     },
     {
         "id":"footer-instructions-4",
         "ui_cn":"3. Click on the tags, up to 6 tags.",
         "ui_en":"3. Click on the tags, up to 6 tags.",
         "ui_jp":"3. Click on the tags, up to 6 tags.",
-        "ui_kr":"3. Click on the tags, up to 6 tags."
+        "ui_kr":"3. 최대 6개까지 태그를 선택하세요."
     },
     {
         "id":"footer-instructions-5",
         "ui_cn":"4. You can hover on the tags to see the translation.",
         "ui_en":"4. You can hover on the tags to see the translation.",
         "ui_jp":"4. You can hover on the tags to see the translation.",
-        "ui_kr":"4. You can hover on the tags to see the translation."
+        "ui_kr":"4. 태그 위에 커서를 올려놓아 번역된 태그를 볼 수 있습니다."
     },
     {
         "id":"footer-instructions-6",
         "ui_cn":"5. You can also hide or show the name and/or the image of the operators.",
         "ui_en":"5. You can also hide or show the name and/or the image of the operators.",
         "ui_jp":"5. You can also hide or show the name and/or the image of the operators.",
-        "ui_kr":"5. You can also hide or show the name and/or the image of the operators."
+        "ui_kr":"5. 또한 대원의 이름이나 사진을 숨기거나 보이게 할 수 있습니다."
     },
     {
         "id":"footer-instructions-7",
         "ui_cn":"6. Click 'clear' to reset all the tag selections.",
         "ui_en":"6. Click 'clear' to reset all the tag selections.",
         "ui_jp":"6. Click 'clear' to reset all the tag selections.",
-        "ui_kr":"6. Click 'clear' to reset all the tag selections."
+        "ui_kr":"6. '태그 초기화하기'를 눌러 선택된 태그를 초기화하세요."
     }
 ]


### PR DESCRIPTION
1. Bug fixed.(maybe) Now dropdown text will change to 'Korean' when change from other language.
(I added just one line at akevolve.html. I don't know if it's working, so check it before you merge.)
2. Add material's name in Korean server.
3. Translate material calculator "How To Use".
4. Translate some words.
5. Fix some unnatural Korean words.

/
I'm a Korean Arknights user who uses your cool site.
When I set language to Korean at 'material calculator', I can see just 'undefined'.
If you need a Korean translation, I thought I could help you, so I modified the files.
I brought materials names from in-game.

I couldn't find what "Synthetic Resin", "Fined Synthetic Resin", "Silicic Alloy" and "Silicic Alloy Block" meant.
and also couldn't find way to fix 'Need', 'Have' and 'Lack' is 'undefined'. (I don't know about HTML.)

If you need more help translating into Korean, discord dm to Zetab_S#3598. I'll help you.