### PR TITLE
[AKHRELITE] akhrelite: add a frame for required mats of added ops

### DIFF
--- a/akhrelite.html
+++ b/akhrelite.html
@@ -24,6 +24,33 @@
         gtag('config', 'UA-159317757-1');
         
     </script>
+    <style>
+        #floating-reqmats-arrow {
+            position: relative;
+            background-color: #444;
+        }
+        #floating-reqmats-arrow::before, #floating-reqmats-arrow::after {
+            top: -2px;
+            left: 50%;
+            border: solid transparent;
+            content: " ";
+            height: 0;
+            width: 0;
+            position: absolute;
+        }
+        #floating-reqmats-arrow::before {
+            border-color: rgba(0, 0, 0, 0);
+            border-top-color: #000;
+            border-width: 13px;
+            margin-left: -13px;
+        }
+        #floating-reqmats-arrow::after {
+            border-color: rgba(68, 68, 68, 0);
+            border-top-color: #444;
+            border-width: 10px;
+            margin-left: -10px;
+        }
+    </style>
 </head>
 <body style="overflow: unset;">
     <!-- style=" background-image: url(./img/extra/bg1.png)" -->

--- a/js/akhrelite.js
+++ b/js/akhrelite.js
@@ -368,7 +368,7 @@
         var opdata = query(db.chars2, "name_cn", db.chars[id].name);
         let name = `${opdata[`name_${lang}`]} E${level}`;
 
-        $("#selectops-container").append(`<li><div style="display: block; padding:2px;"
+        $("#selectops-container").append(`<li><div style="display: block; padding:2px; z-index: 10000"
                                           op-id="${key}"
                                           onmouseover="reqmatsShow(this)"
                                           onmouseout="reqmatsHide(this)"><span> ${name} </span>


### PR DESCRIPTION
This commit is here to fill a gap created by the addition of combined material requirements in akhrelite. Many time, I searched the operators again after composing a list, because I forgot the required materials of each individual operator in the list.

There is no problem to solve, only a little bit of css that have to be cleaned and put at the right place (it couldn't be done solely with style attribute).

I renders (surprisingly) quite nicely :
![aceship_pr29](https://user-images.githubusercontent.com/46849630/76918061-9b34db80-68c5-11ea-8b6f-d71da1078a74.png)

Only weird thing is it flickering when in the collision box of arrow::before or arrow::after. It should have been fixed with the 2nd commit, but it's still there. Don't see any way to fix it as fixing it didn't fix it (~who cares anyway~).