### PR TITLE
fix to correctly search tag in custom input

### DIFF
--- a/js/akhr.js
+++ b/js/akhr.js
@@ -666,23 +666,24 @@
             console.log(currsearch)
             if(currsearch){
                 let all_tags = JsonDATA.tagsTL.concat(JsonDATA.typesTL);
-                var allsearch = []
-                all_tags.forEach(element => {
-                    Object.keys(element).forEach(searchkey => {
-                        if(element[searchkey].toLowerCase().includes(currsearch.toLowerCase())){
-                            if(!allsearch.find(search=>search[1]==element)){
-                                allsearch.push([element[searchkey],element])
-                            }
+                var allsearch = all_tags.reduce((acc, element) => {
+                    Object.entries(element).forEach(([k,v]) => {
+                        if(/^(tag|type)_/.test(k) && v.toLowerCase().includes(currsearch.toLowerCase())){
+                            acc.add(v);
                         }
                     });
-                });
+                    return acc;
+                }, new Set());
                 if(isenter){
-                    console.log(allsearch[0])
-                    var currtag = allsearch[0][1]['tag_'+lang]?allsearch[0][1]['tag_'+lang]:allsearch[0][1]['type_'+lang]
-                    console.log(`button[data-original-title='${currtag}']`)
-                    console.log($(`button[data-original-title='${currtag}']`))
-                    clickBtnTag($(`button[data-original-title='${currtag}']`)[0])
-                    $('#fastInput').val("")
+                    let firstTag = allsearch.values().next().value
+                    if (firstTag) {
+                        console.log(firstTag)
+                        var currtag = firstTag['tag_'+lang]?firstTag['tag_'+lang]:firstTag['type_'+lang]
+                        console.log(`button[data-original-title='${currtag}']`)
+                        console.log($(`button[data-original-title='${currtag}']`))
+                        clickBtnTag($(`button[data-original-title='${currtag}']`)[0])
+                        $('#fastInput').val("")
+                    }
                 }else{
                     console.log(allsearch)
                 }


### PR DESCRIPTION
This fixes the issue where searching for `x` and pressing Enter in Recruitment's custom input will toggle "Healing". This was due to the search checking for all values of the property, and the "Healing" tag is first of many has the type "affix".