### PR TITLE
add missing drop locations

### DIFF
--- a/json/akmaterial.json
+++ b/json/akmaterial.json
@@ -1,9 +1,12 @@
 [
   {
     "id": 0,
+    "itemId": "30135",
     "name_cn": "D32钢",
     "name_en": "D32 Steel",
     "name_kr": "D32강",
+    "name_jp": "D32鋼",
+    "name_tw": "D32鋼",
     "level": 5,
     "source": {},
     "madeof": {
@@ -14,9 +17,12 @@
   },
   {
     "id": 1,
+    "itemId": "30125",
     "name_cn": "双极纳米片",
-    "name_en": "Bipolar Nanoplate",
+    "name_en": "Bipolar Nanoflake",
     "name_kr": "바이폴라 나노플레이크 칩",
+    "name_jp": "ナノフレーク",
+    "name_tw": "雙極納米片",
     "level": 5,
     "source": {},
     "madeof": {
@@ -26,9 +32,12 @@
   },
   {
     "id": 2,
+    "itemId": "30115",
     "name_cn": "聚合剂",
-    "name_en": "Aggregate Agent",
+    "name_en": "Polymerization Preparation",
     "name_kr": "중합제",
+    "name_jp": "融合剤",
+    "name_tw": "聚合劑",
     "level": 5,
     "source": {},
     "madeof": {
@@ -39,12 +48,16 @@
   },
   {
     "id": 3,
+    "itemId": "30104",
     "name_cn": "RMA70-24",
     "name_en": "RMA70-24",
     "name_kr": "RMA70-24",
+    "name_jp": "RMA70-24",
+    "name_tw": "RMA70-24",
     "level": 4,
     "source": {
-      "4-9": "Very Rare"
+      "4-9": "Very Rare",
+      "6-15": "Very Rare"
     },
     "madeof": {
       "RMA70-12": 1,
@@ -54,9 +67,12 @@
   },
   {
     "id": 4,
+    "itemId": "30094",
     "name_cn": "五水研磨石",
-    "name_en": "Pentahydrate Polish Stone",
+    "name_en": "Grindstone Pentahydrate",
     "name_kr": "고급연마석",
+    "name_jp": "上級砥石",
+    "name_tw": "五水研磨石",
     "level": 4,
     "source": {
       "4-8": "Very Rare"
@@ -69,12 +85,16 @@
   },
   {
     "id": 5,
+    "itemId": "30084",
     "name_cn": "三水锰矿",
-    "name_en": "Manganese Block",
+    "name_en": "Manganese Trihydrate",
     "name_kr": "망간 중합체",
+    "name_jp": "上級マンガン",
+    "name_tw": "三水錳礦",
     "level": 4,
     "source": {
-      "4-7": "Very Rare"
+      "4-7": "Very Rare",
+      "6-2": "Very Rare"
     },
     "madeof": {
       "轻锰矿": 2,
@@ -84,9 +104,12 @@
   },
   {
     "id": 6,
+    "itemId": "30074",
     "name_cn": "白马醇",
-    "name_en": "White Horse Alcohol",
+    "name_en": "White Horse Kohl",
     "name_kr": "화이트 호스 콜",
+    "name_jp": "上級合成コール",
+    "name_tw": "白馬醇",
     "level": 4,
     "source": {
       "4-4": "Very Rare"
@@ -99,9 +122,12 @@
   },
   {
     "id": 7,
+    "itemId": "30064",
     "name_cn": "改量装置",
-    "name_en": "Quantum Gadget",
+    "name_en": "Optimized Device",
     "name_kr": "개량 장치",
+    "name_jp": "上級装置",
+    "name_tw": "改量裝置",
     "level": 4,
     "source": {
       "4-10": "Very Rare"
@@ -114,13 +140,16 @@
   },
   {
     "id": 8,
+    "itemId": "30054",
     "name_cn": "酮阵列",
-    "name_en": "Ketone Arrangement",
+    "name_en": "Keton Colloid",
     "name_kr": "아케톤 팩",
+    "name_jp": "上級アケトン",
+    "name_tw": "酮陣列",
     "level": 4,
     "source": {
       "4-5": "Very Rare",
-      "5-8": "Rare"
+      "5-8": "Very Rare"
     },
     "madeof": {
       "酮凝集组": 2,
@@ -130,13 +159,16 @@
   },
   {
     "id": 9,
+    "itemId": "30044",
     "name_cn": "异铁块",
-    "name_en": "Mass Xeno Iron",
+    "name_en": "Oriron Block",
     "name_kr": "이철 팩",
+    "name_jp": "上級異鉄",
+    "name_tw": "異鐵塊",
     "level": 4,
     "source": {
-      "S4-1": "Very Rare",
-      "5-5": "Rare"
+      "5-5": "Very Rare",
+      "S4-1": "Very Rare"
     },
     "madeof": {
       "异铁组": 2,
@@ -146,12 +178,16 @@
   },
   {
     "id": 10,
+    "itemId": "30034",
     "name_cn": "聚酸酯块",
-    "name_en": "Polyester Box",
+    "name_en": "Polyester Lump",
     "name_kr": "폴리에스테르 팩",
+    "name_jp": "上級エステル",
+    "name_tw": "聚酸酯塊",
     "level": 4,
     "source": {
-      "3-8": "Very Rare"
+      "3-8": "Very Rare",
+      "6-4": "Very Rare"
     },
     "madeof": {
       "聚酸酯组": 2,
@@ -161,9 +197,12 @@
   },
   {
     "id": 11,
+    "itemId": "30024",
     "name_cn": "糖聚块",
-    "name_en": "Sugar Box",
+    "name_en": "Sugar Lump",
     "name_kr": "포도당 팩",
+    "name_jp": "上級糖原",
+    "name_tw": "糖聚塊",
     "level": 4,
     "source": {
       "4-2": "Very Rare",
@@ -177,9 +216,12 @@
   },
   {
     "id": 12,
+    "itemId": "30014",
     "name_cn": "提纯源岩",
-    "name_en": "Refined Rock",
+    "name_en": "Orirock Concentration",
     "name_kr": "정제 원암",
+    "name_jp": "上級源岩",
+    "name_tw": "提純源岩",
     "level": 4,
     "source": {
       "4-6": "Very Rare"
@@ -190,14 +232,18 @@
   },
   {
     "id": 13,
+    "itemId": "30063",
     "name_cn": "全新装置",
-    "name_en": "Current Gadget",
+    "name_en": "Integrated Device",
     "name_kr": "리뉴얼 장치",
+    "name_jp": "中級装置",
+    "name_tw": "全新裝置",
     "level": 3,
     "source": {
       "3-4": "Rare",
       "4-10": "Rare",
-      "5-10": "Rare"
+      "5-10": "Rare",
+      "6-16": "Rare"
     },
     "madeof": {
       "装置": 4
@@ -205,14 +251,18 @@
   },
   {
     "id": 14,
+    "itemId": "30053",
     "name_cn": "酮凝集组",
-    "name_en": "Flocculated Ketone Case",
+    "name_en": "Aketon",
     "name_kr": "아케톤 응집체 번들",
+    "name_jp": "中級アケトン",
+    "name_tw": "酮凝集組",
     "level": 3,
     "source": {
       "3-1": "Rare",
       "4-5": "Rare",
-      "5-8": "Rare"
+      "5-8": "Rare",
+      "6-8": "Rare"
     },
     "madeof": {
       "酮凝集": 4
@@ -220,14 +270,18 @@
   },
   {
     "id": 15,
+    "itemId": "30043",
     "name_cn": "异铁组",
-    "name_en": "Xeno Iron Chunk",
+    "name_en": "Oriron Cluster",
     "name_kr": "이철 번들",
+    "name_jp": "中級異鉄",
+    "name_tw": "異鐵組",
     "level": 3,
     "source": {
       "2-8": "Rare",
-      "S4-1": "Rare",
-      "5-5": "Rare"
+      "5-5": "Rare",
+      "6-10": "Rare",
+      "S4-1": "Rare"
     },
     "madeof": {
       "异铁": 4
@@ -235,14 +289,18 @@
   },
   {
     "id": 16,
+    "itemId": "30033",
     "name_cn": "聚酸酯组",
     "name_en": "Polyester Pack",
     "name_kr": "폴리에스테르 번들",
+    "name_jp": "中級エステル",
+    "name_tw": "聚酸酯組",
     "level": 3,
     "source": {
       "2-6": "Rare",
       "3-8": "Rare",
-      "5-3": "Medium"
+      "5-3": "Medium",
+      "6-4": "Rare"
     },
     "madeof": {
       "聚酸酯": 4
@@ -250,14 +308,18 @@
   },
   {
     "id": 17,
+    "itemId": "30023",
     "name_cn": "糖组",
     "name_en": "Sugar Pack",
     "name_kr": "포도당 번들",
+    "name_jp": "中級糖原",
+    "name_tw": "糖組",
     "level": 3,
     "source": {
       "2-5": "Rare",
       "4-2": "Rare",
-      "5-2": "Very Rare"
+      "5-2": "Rare",
+      "6-3": "Rare"
     },
     "madeof": {
       "糖": 4
@@ -265,14 +327,18 @@
   },
   {
     "id": 18,
+    "itemId": "30013",
     "name_cn": "固源岩组",
-    "name_en": "Rock Set",
+    "name_en": "Orirock Cluster",
     "name_kr": "원암 큐브 번들",
+    "name_jp": "中級源岩",
+    "name_tw": "固源岩組",
     "level": 3,
     "source": {
       "2-4": "Rare",
       "4-6": "Rare",
-      "5-1": "Rare"
+      "5-1": "Rare",
+      "6-5": "Medium"
     },
     "madeof": {
       "固源岩": 5
@@ -280,12 +346,16 @@
   },
   {
     "id": 19,
+    "itemId": "30062",
     "name_cn": "装置",
-    "name_en": "Gadget",
+    "name_en": "Device",
     "name_kr": "장치",
+    "name_jp": "初級装置",
+    "name_tw": "裝置",
     "level": 2,
     "source": {
       "1-12": "Medium",
+      "6-11": "Medium",
       "S3-4": "Common",
       "S5-5": "Medium"
     },
@@ -295,13 +365,18 @@
   },
   {
     "id": 20,
+    "itemId": "30052",
     "name_cn": "酮凝集",
-    "name_en": "Flocculated Ketone",
+    "name_en": "Polyketon",
     "name_kr": "아케톤 응집체",
+    "name_jp": "初級アケトン",
+    "name_tw": "酮凝集",
     "level": 2,
     "source": {
       "S2-1": "Medium",
-      "3-7": "Always"
+      "3-7": "Always",
+      "6-16": "Medium",
+      "S6-3": "Common"
     },
     "madeof": {
       "双酮": 3
@@ -309,14 +384,18 @@
   },
   {
     "id": 21,
+    "itemId": "30042",
     "name_cn": "异铁",
-    "name_en": "Xeno Iron",
+    "name_en": "Oriron",
     "name_kr": "이철",
+    "name_jp": "初級異鉄",
+    "name_tw": "異鐵",
     "level": 2,
     "source": {
       "2-1": "Medium",
-      "S3-3": "Always",
-      "5-7": "Medium"
+      "5-7": "Medium",
+      "6-1": "Common",
+      "S3-3": "Always"
     },
     "madeof": {
       "异铁碎片": 3
@@ -324,12 +403,17 @@
   },
   {
     "id": 22,
+    "itemId": "30032",
     "name_cn": "聚酸酯",
     "name_en": "Polyester",
     "name_kr": "폴리에스테르",
+    "name_jp": "初級エステル",
+    "name_tw": "聚酸酯",
     "level": 2,
     "source": {
       "1-8": "Common",
+      "6-5": "Rare",
+      "6-9": "Always",
       "S3-2": "Always",
       "S5-3": "Always"
     },
@@ -339,15 +423,18 @@
   },
   {
     "id": 23,
+    "itemId": "30022",
     "name_cn": "糖",
     "name_en": "Sugar",
     "name_kr": "포도당",
+    "name_jp": "初級糖原",
+    "name_tw": "糖",
     "level": 2,
     "source": {
       "2-2": "Common",
-      "S3-1": "Always",
       "5-3": "Medium",
-      "S5-3": "Always"
+      "S3-1": "Always",
+      "S5-4": "Always"
     },
     "madeof": {
       "代糖": 3
@@ -355,15 +442,19 @@
   },
   {
     "id": 24,
+    "itemId": "30012",
     "name_cn": "固源岩",
-    "name_en": "Rock Block",
+    "name_en": "Orirock Cube",
     "name_kr": "원암 큐브",
+    "name_jp": "初級源岩",
+    "name_tw": "固源岩",
     "level": 2,
     "source": {
       "1-7": "Always",
       "S2-12": "Always",
-      "S5-1": "Always",
-      "5-10": "Medium"
+      "5-10": "Medium",
+      "S6-2": "Always",
+      "S5-1": "Always"
     },
     "madeof": {
       "源岩": 3
@@ -371,9 +462,12 @@
   },
   {
     "id": 25,
+    "itemId": "30061",
     "name_cn": "破损装置",
-    "name_en": "Broken Gadget",
+    "name_en": "Damaged Device",
     "name_kr": "파손된 장치",
+    "name_jp": "破損装置",
+    "name_tw": "破損裝置",
     "level": 1,
     "source": {
       "1-5": "Medium",
@@ -383,9 +477,12 @@
   },
   {
     "id": 26,
+    "itemId": "30051",
     "name_cn": "双酮",
-    "name_en": "Ketone",
+    "name_en": "Diketon",
     "name_kr": "디케톤",
+    "name_jp": "アケトン試剤",
+    "name_tw": "雙酮",
     "level": 1,
     "source": {
       "1-6": "Common",
@@ -395,9 +492,12 @@
   },
   {
     "id": 27,
+    "itemId": "30041",
     "name_cn": "异铁碎片",
-    "name_en": "Xeno Iron Shard",
+    "name_en": "Oriron Shard",
     "name_kr": "이철 조각",
+    "name_jp": "異鉄の欠片",
+    "name_tw": "異鐵碎片",
     "level": 1,
     "source": {
       "1-3": "Common",
@@ -407,9 +507,12 @@
   },
   {
     "id": 28,
+    "itemId": "30031",
     "name_cn": "酯原料",
-    "name_en": "Raw Ester",
+    "name_en": "Ester",
     "name_kr": "에스테르 원료",
+    "name_jp": "エステル原料",
+    "name_tw": "酯原料",
     "level": 1,
     "source": {
       "0-11": "Always",
@@ -419,9 +522,12 @@
   },
   {
     "id": 29,
+    "itemId": "30021",
     "name_cn": "代糖",
     "name_en": "Sugar Substitute",
     "name_kr": "대체당",
+    "name_jp": "ブドウ糖",
+    "name_tw": "代糖",
     "level": 1,
     "source": {
       "0-7": "Always",
@@ -431,9 +537,12 @@
   },
   {
     "id": 30,
+    "itemId": "30011",
     "name_cn": "源岩",
-    "name_en": "Rock",
+    "name_en": "Orirock",
     "name_kr": "원암",
+    "name_jp": "源岩鉱",
+    "name_tw": "源岩",
     "level": 1,
     "source": {
       "0-9": "Always",
@@ -443,85 +552,110 @@
   },
   {
     "id": 31,
+    "itemId": "30073",
     "name_cn": "扭转醇",
-    "name_en": "Twist Alcohol",
+    "name_en": "Loxic Kohl",
     "name_kr": "로식 콜",
+    "name_jp": "合成コール",
+    "name_tw": "扭轉醇",
     "level": 3,
     "source": {
       "2-9": "Rare",
       "4-4": "Rare",
-      "5-4": "Rare"
+      "5-4": "Rare",
+      "6-11": "Medium"
     },
     "madeof": {}
   },
   {
     "id": 32,
+    "itemId": "30093",
     "name_cn": "研磨石",
-    "name_en": "Polish Stone",
+    "name_en": "Grindstone",
     "name_kr": "연마석",
+    "name_jp": "砥石",
+    "name_tw": "研磨石",
     "level": 3,
     "source": {
       "3-3": "Rare",
       "4-8": "Rare",
-      "5-7": "Rare"
+      "5-7": "Rare",
+      "6-14": "Rare"
     },
     "madeof": {}
   },
   {
     "id": 33,
+    "itemId": "30083",
     "name_cn": "轻锰矿",
     "name_en": "Manganese Ore",
     "name_kr": "망간 광석",
+    "name_jp": "マンガン",
+    "name_tw": "輕錳礦",
     "level": 3,
     "source": {
       "3-2": "Rare",
       "4-7": "Rare",
-      "5-6": "Rare"
+      "5-6": "Rare",
+      "6-2": "Rare"
     },
     "madeof": {}
   },
   {
     "id": 34,
+    "itemId": "30103",
     "name_cn": "RMA70-12",
     "name_en": "RMA70-12",
     "name_kr": "RMA70-12",
+    "name_jp": "RMA70-12",
+    "name_tw": "RMA70-12",
     "level": 3,
     "source": {
       "2-10": "Rare",
       "4-9": "Rare",
-      "5-9": "Rare"
+      "5-9": "Rare",
+      "6-15": "Rare"
     },
     "madeof": {}
   },
   {
     "id": 35,
+    "itemId": "3211",
     "name_cn": "先锋芯片",
     "name_en": "Vanguard Chip",
     "name_kr": "뱅가드 칩",
+    "name_jp": "初級先鋒SoC",
+    "name_tw": "先鋒晶片",
     "level": 2,
     "source": {
-      "PR-C-1": "Always"
+      "PR-C-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 36,
+    "itemId": "3212",
     "name_cn": "先锋芯片组",
-    "name_en": "Vanguard Chip Set",
+    "name_en": "Vanguard Chip Pack",
     "name_kr": "뱅가드 칩셋",
+    "name_jp": "中級先鋒SoC",
+    "name_tw": "先鋒晶片組",
     "level": 3,
     "source": {
-      "PR-C-2": "Always"
+      "PR-C-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 37,
+    "itemId": "3213",
     "name_cn": "先锋双芯片",
-    "name_en": "Vanguard Twin Chip",
+    "name_en": "Vanguard Dualchip",
     "name_kr": "뱅가드 듀얼 칩",
+    "name_jp": "上級先鋒SoC",
+    "name_tw": "先鋒雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -529,33 +663,42 @@
   },
   {
     "id": 38,
+    "itemId": "3221",
     "name_cn": "近卫芯片",
     "name_en": "Guard Chip",
     "name_kr": "가드 칩",
+    "name_jp": "初級前衛SoC",
+    "name_tw": "近衛晶片",
     "level": 2,
     "source": {
-      "PR-D-1": "Always"
+      "PR-D-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 39,
+    "itemId": "3222",
     "name_cn": "近卫芯片组",
-    "name_en": "Guard Chip Set",
+    "name_en": "Guard Chip Pack",
     "name_kr": "가드 칩셋",
+    "name_jp": "中級前衛SoC",
+    "name_tw": "近衛晶片組",
     "level": 3,
     "source": {
-      "PR-D-2": "Always"
+      "PR-D-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 40,
+    "itemId": "3223",
     "name_cn": "近卫双芯片",
-    "name_en": "Guard Twin Chip",
+    "name_en": "Guard Dualchip",
     "name_kr": "가드 듀얼 칩",
+    "name_jp": "上級前衛SoC",
+    "name_tw": "近衛雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -563,33 +706,42 @@
   },
   {
     "id": 41,
+    "itemId": "3231",
     "name_cn": "重装芯片",
-    "name_en": "Tank Chip",
+    "name_en": "Defender Chip",
     "name_kr": "디펜더 칩",
+    "name_jp": "初級重装SoC",
+    "name_tw": "重裝晶片",
     "level": 2,
     "source": {
-      "PR-A-1": "Always"
+      "PR-A-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 42,
+    "itemId": "3232",
     "name_cn": "重装芯片组",
-    "name_en": "Tank Chip Set",
+    "name_en": "Defender Chip Pack",
     "name_kr": "디펜더 칩셋",
+    "name_jp": "中級重装SoC",
+    "name_tw": "重裝晶片組",
     "level": 3,
     "source": {
-      "PR-A-2": "Always"
+      "PR-A-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 43,
+    "itemId": "3233",
     "name_cn": "重装双芯片",
-    "name_en": "Tank Twin Chip",
+    "name_en": "Defender Dualchip",
     "name_kr": "디펜더 듀얼 칩",
+    "name_jp": "上級重装SoC",
+    "name_tw": "重裝雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -597,33 +749,42 @@
   },
   {
     "id": 44,
+    "itemId": "3241",
     "name_cn": "狙击芯片",
     "name_en": "Sniper Chip",
     "name_kr": "스나이퍼 칩",
+    "name_jp": "初級狙撃SoC",
+    "name_tw": "狙擊晶片",
     "level": 2,
     "source": {
-      "PR-B-1": "Always"
+      "PR-B-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 45,
+    "itemId": "3242",
     "name_cn": "狙击芯片组",
-    "name_en": "Sniper Chip Set",
+    "name_en": "Sniper Chip Pack",
     "name_kr": "스나이퍼 칩셋",
+    "name_jp": "中級狙撃SoC",
+    "name_tw": "狙擊晶片組",
     "level": 3,
     "source": {
-      "PR-B-2": "Always"
+      "PR-B-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 46,
+    "itemId": "3243",
     "name_cn": "狙击双芯片",
-    "name_en": "Sniper Twin Chip",
+    "name_en": "Sniper Dualchip",
     "name_kr": "스나이퍼 듀얼 칩",
+    "name_jp": "上級狙撃SoC",
+    "name_tw": "狙擊雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -631,33 +792,42 @@
   },
   {
     "id": 47,
+    "itemId": "3251",
     "name_cn": "术师芯片",
     "name_en": "Caster Chip",
     "name_kr": "캐스터 칩",
+    "name_jp": "初級術師SoC",
+    "name_tw": "術師晶片",
     "level": 2,
     "source": {
-      "PR-B-1": "Always"
+      "PR-B-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 48,
+    "itemId": "3252",
     "name_cn": "术师芯片组",
-    "name_en": "Caster Chip Set",
+    "name_en": "Caster Chip Pack",
     "name_kr": "캐스터 칩셋",
+    "name_jp": "中級術師SoC",
+    "name_tw": "術師晶片組",
     "level": 3,
     "source": {
-      "PR-B-2": "Always"
+      "PR-B-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 49,
+    "itemId": "3253",
     "name_cn": "术师双芯片",
-    "name_en": "Caster Twin Chip",
+    "name_en": "Caster Dualchip",
     "name_kr": "캐스터 듀얼 칩",
+    "name_jp": "上級術師SoC",
+    "name_tw": "術師雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -665,33 +835,42 @@
   },
   {
     "id": 50,
+    "itemId": "3261",
     "name_cn": "医疗芯片",
     "name_en": "Medic Chip",
     "name_kr": "메딕 칩",
+    "name_jp": "初級医療SoC",
+    "name_tw": "醫療晶片",
     "level": 2,
     "source": {
-      "PR-A-1": "Always"
+      "PR-A-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 51,
+    "itemId": "3262",
     "name_cn": "医疗芯片组",
-    "name_en": "Medic Chip Set",
+    "name_en": "Medic Chip Pack",
     "name_kr": "메딕 칩셋",
+    "name_jp": "中級医療SoC",
+    "name_tw": "醫療晶片組",
     "level": 3,
     "source": {
-      "PR-A-2": "Always"
+      "PR-A-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 52,
+    "itemId": "3263",
     "name_cn": "医疗双芯片",
-    "name_en": "Medic Twin Chip",
+    "name_en": "Medic Dualchip",
     "name_kr": "메딕 듀얼 칩",
+    "name_jp": "上級医療SoC",
+    "name_tw": "醫療雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -699,33 +878,42 @@
   },
   {
     "id": 53,
+    "itemId": "3271",
     "name_cn": "辅助芯片",
-    "name_en": "Support Chip",
+    "name_en": "Supporter Chip",
     "name_kr": "서포터 칩",
+    "name_jp": "初級補助SoC",
+    "name_tw": "輔助晶片",
     "level": 2,
     "source": {
-      "PR-C-1": "Always"
+      "PR-C-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 54,
+    "itemId": "3272",
     "name_cn": "辅助芯片组",
-    "name_en": "Support Chip Set",
+    "name_en": "Supporter Chip Pack",
     "name_kr": "서포터 칩셋",
+    "name_jp": "中級補助SoC",
+    "name_tw": "輔助晶片組",
     "level": 3,
     "source": {
-      "PR-C-2": "Always"
+      "PR-C-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 55,
+    "itemId": "3273",
     "name_cn": "辅助双芯片",
-    "name_en": "Support Twin Chip",
+    "name_en": "Supporter Dualchip",
     "name_kr": "서포터 듀얼 칩",
+    "name_jp": "上級補助SoC",
+    "name_tw": "輔助雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -733,33 +921,42 @@
   },
   {
     "id": 56,
+    "itemId": "3281",
     "name_cn": "特种芯片",
     "name_en": "Specialist Chip",
     "name_kr": "스페셜리스트 칩",
+    "name_jp": "初級特殊SoC",
+    "name_tw": "特種晶片",
     "level": 2,
     "source": {
-      "PR-D-1": "Always"
+      "PR-D-1": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 57,
+    "itemId": "3282",
     "name_cn": "特种芯片组",
-    "name_en": "Specialist Chip Set",
+    "name_en": "Specialist Chip Pack",
     "name_kr": "스페셜리스트 칩셋",
+    "name_jp": "中級特殊SoC",
+    "name_tw": "特種晶片組",
     "level": 3,
     "source": {
-      "PR-D-2": "Always"
+      "PR-D-2": "Medium"
     },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 58,
+    "itemId": "3283",
     "name_cn": "特种双芯片",
-    "name_en": "Specialist Twin Chip",
+    "name_en": "Specialist Dualchip",
     "name_kr": "스페셜리스트 듀얼 칩",
+    "name_jp": "上級特殊SoC",
+    "name_tw": "特種雙晶片",
     "level": 4,
     "source": {},
     "madeof": {},
@@ -767,19 +964,35 @@
   },
   {
     "id": 59,
+    "itemId": "4001",
     "name_cn": "龙门币",
-    "name_en": "Lungmen Coin",
+    "name_en": "LMD",
     "name_kr": "용문폐",
+    "name_jp": "龍門幣",
+    "name_tw": "龍門幣",
     "level": 1,
-    "source": {},
+    "source": {
+      "CE-5": "Always",
+      "1-1": "Always",
+      "S2-2": "Always",
+      "2-7": "Always",
+      "3-6": "Always",
+      "4-1": "Always",
+      "S6-4": "Always",
+      "S4-6": "Always",
+      "S5-2": "Always"
+    },
     "madeof": {},
     "hidden": true
   },
   {
     "id": 60,
+    "itemId": "32001",
     "name_cn": "芯片助剂",
-    "name_en": "Chip Additive",
-    "name_kr": "칩 촉매제",
+    "name_en": "Chip Catalyst",
+    "name_kr": "칩 첨가제",
+    "name_jp": "SoC強化剤",
+    "name_tw": "晶片助劑",
     "level": 1,
     "source": {},
     "madeof": {},
@@ -787,51 +1000,70 @@
   },
   {
     "id": 61,
+    "itemId": "31023",
     "name_cn": "炽合金",
-    "name_en": "Silicic Alloy",
-    "name_kr": "",
+    "name_en": "Incandescent Alloy",
+    "name_kr": "열합금",
+    "name_jp": "熾合金",
+    "name_tw": "",
     "level": 3,
     "source": {
-      
+      "6-12": "Rare",
+      "S3-6": "Rare",
+      "S5-8": "Rare"
     },
     "madeof": {}
   },
   {
     "id": 62,
+    "itemId": "31024",
     "name_cn": "炽合金块",
-    "name_en": "Silicic Alloy Block",
-    "name_kr": "",
+    "name_en": "Incandescent Alloy Block",
+    "name_kr": "열합금 팩",
+    "name_jp": "上級熾合金",
+    "name_tw": "",
     "level": 4,
     "source": {
+      "6-12": "Very Rare",
+      "S5-8": "Very Rare"
     },
     "madeof": {
       "炽合金": 1,
       "研磨石": 1,
-      "全新装置":1
+      "全新装置": 1
     }
   },
   {
     "id": 63,
+    "itemId": "31013",
     "name_cn": "凝胶",
-    "name_en": "Synthetic Resin",
-    "name_kr": "",
+    "name_en": "Coagulating Gel",
+    "name_kr": "젤",
+    "name_jp": "人工ゲル",
+    "name_tw": "",
     "level": 3,
     "source": {
+      "S4-10": "Rare",
+      "S5-7": "Rare"
     },
     "madeof": {}
   },
   {
     "id": 64,
+    "itemId": "31014",
     "name_cn": "聚合凝胶",
-    "name_en": "Fined Synthetic Resin",
-    "name_kr": "",
+    "name_en": "Polymerized Gel",
+    "name_kr": "중합젤",
+    "name_jp": "融合ゲル",
+    "name_tw": "",
     "level": 4,
     "source": {
+      "S5-7": "Very Rare"
     },
     "madeof": {
       "炽合金": 1,
       "凝胶": 1,
-      "异铁组":1
+      "异铁组": 1
     }
   }
 ]


### PR DESCRIPTION
Changes:
- Fixes issues #71 and #67.
- Added `itemId`. (Useful for referencing gamedata)
- Added JP and TW names.
- Using official item names of each region (mainly an issue with EN as item names did not match in-game names).
