### PR TITLE
fix character image scaling w/ drag

### DIFF
--- a/akhrchars.html
+++ b/akhrchars.html
@@ -215,7 +215,7 @@
             </div>
         -->
             <!-- Modal body -->
-            <div class="modal-body" style="padding:0px;margin:0px;min-height:88vh;max-height: 88vh;display: flex">
+            <div class="modal-body" style="padding:0px;margin:0px;min-height:88vh;max-height: 88vh;display: block">
                 <img id="charazoom" style="margin-left:auto;width:100%;height:100%; display: block;object-fit: contain;">
             </div>
         


### PR DESCRIPTION
display: flex causes the character image to resize weirdly when dragging outside of the modal boundaries, especially with non-default zoom levels.
display: block fixes on desktop chrome + firefox.