### PR TITLE
Update Bubble's RIIC skill description to match EN

### DIFF
--- a/json/ace/riic.json
+++ b/json/ace/riic.json
@@ -371,8 +371,8 @@
 	},
 	"manu_prod_spd_variable3[000]": {
 		"name": "\"Bigger is Better!\"",
-		"desc": "When stationed at a Craft Station, operators in the current Craft Station increase production based on the storage capacity they provide. Operators with 16 or less storage capacity gain 1% production per storage capacity; Operators with more than 16 storage capacity gain 3% production per storage capacity (Does not stack with [Recycling], and takes priority over it)",
-		"descformat": "When stationed at a Craft Station, operators in the current Craft Station increase production based on the storage capacity they provide. Operators with <@cc.vup>16</> or less storage capacity gain <@cc.vup>1%</> production per storage capacity; Operators with more than <@cc.vup>16</> storage capacity gain <@cc.vup>3%</> production per storage capacity (Does not stack with <$cc.m.var1><@cc.rem>[Recycling]</></>, and takes priority over it)"
+		"desc": "When stationed at a Craft Station, operators in the current Craft Station increase production based on the storage capacity they provide. Operators with 18 or less storage capacity gain 1% production per storage capacity; Operators with more than 18 storage capacity gain 3% production per storage capacity (Does not stack with [Recycling], and takes priority over it)",
+		"descformat": "When stationed at a Craft Station, operators in the current Craft Station increase production based on the storage capacity they provide. Operators with <@cc.vup>18</> or less storage capacity gain <@cc.vup>1%</> production per storage capacity; Operators with more than <@cc.vup>18</> storage capacity gain <@cc.vup>3%</> production per storage capacity (Does not stack with <$cc.m.var1><@cc.rem>[Recycling]</></>, and takes priority over it)"
 	},
 	"manu_prod_spd_variable2[000]": {
 		"name": "Sense of Cooperation",


### PR DESCRIPTION
I'm not sure whether I did it properly, though. Bigger is Better!'s activation threshold is 18 on EN and that's what I tried to change it to.