### PR TITLE
Return an empty object if fetch fails

### DIFF
--- a/js/chara-detail.js
+++ b/js/chara-detail.js
@@ -5960,7 +5960,7 @@
             return $.getJSON(url[1]).then(function (res) {
                 result[url[0]] = res
             }).catch(function (e) {
-                console.error("Failed to load file:", e);
+                console.error("Failed to load file: " + url[0], e);
                 result[url[0]] = {}
             });
         })

--- a/js/chara-detail.js
+++ b/js/chara-detail.js
@@ -5957,9 +5957,12 @@
         var result = {}
         
         var promises = Object.entries(obj).map(function(url){
-            return $.getJSON(url[1]).then(function(res){
-                result[url[0]]=res
-            })
+            return $.getJSON(url[1]).then(function (res) {
+                result[url[0]] = res
+            }).catch(function (e) {
+                console.error("Failed to load file:", e);
+                result[url[0]] = {}
+            });
         })
     
         return Promise.all(promises).then(function(){


### PR DESCRIPTION
This shouldn't happen for any of the local files (like `./json/some/file.json`), but in the case where one of the JSON files is a remote resource (like `sanitygone`), catch the failed fetch and return an empty object instead.

This will essentially mean that no operator pages show a Sanity;Gone link if the fetch fails, but the site is down if the fetch failed anyway so it's not any loss for the user.

Sorry for the inconvenience 🙏🏼 