### PR TITLE
Update global recruitment

### DIFF
--- a/json/tl-akhr.json
+++ b/json/tl-akhr.json
@@ -2281,7 +2281,7 @@
 			"资深干员"
 		],
 		"hidden": false,
-		"globalHidden":true
+		"globalHidden":false
 	},
 	{
 		"name_cn": "布洛卡",
@@ -2302,7 +2302,7 @@
 			"资深干员"
 		],
 		"hidden": false,
-		"globalHidden":true
+		"globalHidden":false
 	},
 	{
 		"name_cn": "安比尔",
@@ -2322,7 +2322,7 @@
 			"减速"
 		],
 		"hidden": false,
-		"globalHidden":true
+		"globalHidden":false
 	},
 	{
 		"name_cn": "灰喉",
@@ -2343,7 +2343,7 @@
 			"资深干员"
 		],
 		"hidden": false,
-		"globalHidden":true
+		"globalHidden":false
 	},
 	{
 		"name_cn": "煌",
@@ -2365,7 +2365,7 @@
 			"高级资深干员"
 		],
 		"hidden": false,
-		"globalHidden": true
+		"globalHidden": false
 	},
 	{
 		"name_cn": "雪雉",


### PR DESCRIPTION
The following operators were added to recruitment on Global with the 2nd Anniversary:
- Ambriel
- Blaze
- Broca
- GreyThroat
- Reed

This should resolve #117 