### PR TITLE
fix duplicate operator tags

### DIFF
--- a/js/akhr.js
+++ b/js/akhr.js
@@ -42,6 +42,7 @@
                     } else {
                         char.tags.push(char.sex);
                     }
+                    char.tags = Array.from(new Set(char.tags));
                     $.each(char.tags, function (_, tag) {
                         if (tag in tags_aval) {
                             tags_aval[tag].push({ 

--- a/json/tl-akhr.json
+++ b/json/tl-akhr.json
@@ -2413,8 +2413,7 @@
 			"近战位",
 			"群攻",
 			"生存",
-			"资深干员",
-			"群攻"
+			"资深干员"
 		],
 		"hidden": false,
 		"globalHidden": false


### PR DESCRIPTION
Fixes #128 and fixes #131 by ensuring operator tags are "unique" (using a `Set`).
A better fix would be to store tag ID instead of tag name in the JSON.