### PR TITLE
Update Global Recruitment

### DIFF
--- a/json/tl-akhr.json
+++ b/json/tl-akhr.json
@@ -2611,7 +2611,7 @@
 			"控场"
 		],
 		"hidden": false,
-		"globalHidden":true
+		"globalHidden":false
 	},
 	{
 		"id": "char_306_leizi",
@@ -2633,7 +2633,7 @@
 			"输出"
 		],
 		"hidden": false,
-		"globalHidden":true
+		"globalHidden":false
 	},
 	{
 		"id": "char_385_finlpp",
@@ -2655,7 +2655,7 @@
 			"远程位"
 		],
 		"hidden": false,
-		"globalHidden": true
+		"globalHidden": false
 	},
 	{
 		"id": "char_222_bpipe",

--- a/json/tl-akhr.json
+++ b/json/tl-akhr.json
@@ -2624,7 +2624,7 @@
 		"characteristic_jp": "",
 		"characteristic_kr": "",
 		"camp": "",
-		"type": "",
+		"type": "术师",
 		"level": 5,
 		"sex": "女",
 		"tags": [


### PR DESCRIPTION
The following operators were added to recruitment on Global with the Invitation to Wine event:
- Ceobe
- Leizi
- Purestream

Also added the missing 'Caster' type (class) property for Leizi so she will now be listed when using the 'Caster' filter.

---

Resolves #148